### PR TITLE
Implement scrolling ahead when skipping through search results with arrow down key

### DIFF
--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -1376,7 +1376,6 @@ window.initSearch = function(rawSearchIndex) {
             if (e.which === 38) { // up
                 var previous = document.activeElement.previousElementSibling;
                 if (previous) {
-                    console.log("previousElementSibling", previous);
                     previous.focus();
                 } else {
                     searchState.focus();

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -1364,6 +1364,7 @@ window.initSearch = function(rawSearchIndex) {
         };
         searchState.input.onpaste = searchState.input.onchange;
 
+        var sidebar = document.querySelector("nav.sidebar");
         searchState.outputElement().addEventListener("keydown", function(e) {
             // We only handle unmodified keystrokes here. We don't want to interfere with,
             // for instance, alt-left and alt-right for history navigation.
@@ -1385,6 +1386,12 @@ window.initSearch = function(rawSearchIndex) {
                 var next = document.activeElement.nextElementSibling;
                 if (next) {
                     next.focus();
+                    // Scroll ahead if we are at the bottom of a page to prevent overlapping
+                    var sidebar_rect = sidebar.getBoundingClientRect();
+                    var next_rect = next.getBoundingClientRect();
+                    if (sidebar_rect.height < next_rect.bottom + next_rect.height) {
+                        window.scrollTo(window.screenX, window.scrollY + next_rect.height);
+                    }
                 }
                 e.preventDefault();
             } else if (e.which === 37) { // left


### PR DESCRIPTION
Hi @jsha 

This fixes the visibility problem in modern browsers that overlay status and link information on the last row.
As mentioned in https://github.com/rust-lang/rust/pull/84462

Cheers,
Stefan